### PR TITLE
Erik Küchler - Abgabe zu ha1 

### DIFF
--- a/app/src/main/java/htw/berlin/prog2/ha1/Calculator.java
+++ b/app/src/main/java/htw/berlin/prog2/ha1/Calculator.java
@@ -33,6 +33,8 @@ public class Calculator {
 
         if(screen.equals("0") || latestValue == Double.parseDouble(screen)) screen = "";
 
+        if (screen.length() >= 9) return;
+
         screen = screen + digit;
     }
 

--- a/app/src/main/java/htw/berlin/prog2/ha1/Calculator.java
+++ b/app/src/main/java/htw/berlin/prog2/ha1/Calculator.java
@@ -83,7 +83,7 @@ public class Calculator {
         screen = Double.toString(result);
         if(screen.equals("NaN")) screen = "Error";
         if(screen.contains(".") && screen.length() > 11) screen = screen.substring(0, 10);
-
+        if(screen.endsWith(".0")) screen = screen.substring(0,screen.length()-2);
     }
 
     /**

--- a/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
+++ b/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
@@ -90,5 +90,19 @@ class CalculatorTest {
 
 
     //TODO hier weitere Tests erstellen
+    @Test
+    @DisplayName("should not display the numbers added before pressing the clear key")
+    void testClearKeyScreen() {
+        Calculator calc = new Calculator();
+
+        calc.pressDigitKey(5);
+        calc.pressClearKey();
+        calc.pressDigitKey(3);
+
+        String expected = "3";
+        String actual = calc.readScreen();
+
+        assertEquals(expected, actual);
+    }
 }
 

--- a/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
+++ b/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
@@ -119,5 +119,30 @@ class CalculatorTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    @DisplayName("should only display a maximum of 9 digits on the calculator screen")
+    void testMaxDisplayableDigits() {
+        Calculator calc = new Calculator();
+
+        calc.pressDigitKey(1);
+        calc.pressDigitKey(2);
+        calc.pressDigitKey(3);
+        calc.pressDigitKey(4);
+        calc.pressDigitKey(5);
+        calc.pressDigitKey(6);
+        calc.pressDigitKey(7);
+        calc.pressDigitKey(8);
+        calc.pressDigitKey(9);
+
+        calc.pressDigitKey(1);
+        calc.pressDigitKey(2);
+        calc.pressDigitKey(3);
+        
+        String expected = "123456789";
+        String actual = calc.readScreen();
+
+        assertEquals(expected, actual);
+    }
 }
 

--- a/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
+++ b/app/src/test/java/htw/berlin/prog2/ha1/CalculatorTest.java
@@ -104,5 +104,20 @@ class CalculatorTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    @DisplayName("should not display a trailing .0 for unary operations")
+    void testUnaryTrailingDotZero() {
+        Calculator calc = new Calculator();
+
+        calc.pressDigitKey(9);
+        calc.pressUnaryOperationKey("√");
+        
+        
+        String expected = "3";
+        String actual = calc.readScreen();
+
+        assertEquals(expected, actual);
+    }
 }
 


### PR DESCRIPTION
Hier meine erste Abgabe.
Matrikelnummer: s0588361

Mein erster Test überprüft, ob vor dem Drücken der Löschtaste eingegebene Zahlen noch angezeigt werden. Da dies nicht der Fall ist, sollte der Test direkt grün werden. Der zweite Test überprüft, ob bei unären Operationen ein ".0" angehangen wird. Ist dies der Fall, wird der Test rot. Der Fix ist, in "pressUnaryOperationKey" wie auch bereits in "pressEqualsKey" mit einer if-Abfrage gegebenenfalls die ".0" zu entfernen. Der dritte Test überprüft, ob mehr als 9 Ziffern auf dem Bildschirm des Taschenrechners angezeigt werden. Ist dies der Fall, wird der Test rot. Der Fix ist, in "pressDigitKey" die Eingabe auf 9 Ziffern zu beschränken. Ich habe versucht, minimalistisch vorzugehen, um neue Fehler durch die Behebungen zu vermeiden. 

Mit freundlichen Grüßen,
Erik Küchler